### PR TITLE
Doesn't work with only the wildcard as version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the Kint Bundle in your `composer.json` file:
 ```js
 {
     "require": {
-        "cg/kint-bundle": "*"
+        "cg/kint-bundle": "dev-master"
     }
 }
 ```


### PR DESCRIPTION
It appears that a version has to be specified for composer to be able to find one. A wildcard alone is not enough (anymore?).
