### PR TITLE
Remove the check to see if the environment is debug. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,6 @@ If you don´t include any variable names in your kint() call, like this:
 
 then the whole Twig Context with all its variables will be dumped.
 
-Kint will only show this output if debug is true (usally this is the case for the dev environment, while it is false in the prod environment)
-
 Configuration
 =============
 
@@ -134,7 +132,7 @@ cg_kint:
     string_length:    60
 ```
 
-- The `enabled` parameter defines if kint output is enabled or not. Set this to false and Kint will not output anything, not even in debug mode.
+- The `enabled` parameter defines if kint output is enabled or not. Set this to false and Kint will not output anything, you probably want to set this to false for the prod environment.
 - The `nesting_depth` parameter defines the maximum depth of nesting in object/array variables that Kint will show. Use 0 for infinite depth. Kint will recognize recursion in variables and will not hang your browser.
 - The `string_length` parameter defines the maximum lenth of strings shown. If a string is longer than that it will be shown truncated with a link to see it fully.
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -106,8 +106,6 @@ If you don´t include any variable names in your kint() call, like this:
 
 then the whole Twig Context with all its variables will be dumped.
 
-Kint will only show this output if debug is true (usally this is the case for the dev environment, while it is false in the prod environment)
-
 Configuration
 =============
 
@@ -118,7 +116,7 @@ In your ``app/config/config.yml`` file you can include::
         nesting_depth:    5
         string_length:    60
 
-- The ``enabled`` parameter defines if kint output is enabled or not. Set this to false and Kint will not output anything, not even in debug mode.
+- The ``enabled`` parameter defines if kint output is enabled or not. Set this to false and Kint will not output anything, you probably want to set this to false for the prod environment.
 - The ``nesting_depth`` parameter defines the maximum depth of nesting in object/array variables that Kint will show. Use 0 for infinite depth. Kint will recognize recursion in variables and will not hang your browser.
 - The ``string_length`` parameter defines the maximum lenth of strings shown. If a string is longer than that it will be shown truncated with a link to see it fully.
 

--- a/Twig/Extension/KintExtension.php
+++ b/Twig/Extension/KintExtension.php
@@ -12,7 +12,6 @@
 namespace Cg\KintBundle\Twig\Extension;
 use Twig_Extension;
 use Twig_Function_Method;
-use Twig_Environment;
 use Kint;
 
 class KintExtension extends Twig_Extension
@@ -38,7 +37,7 @@ class KintExtension extends Twig_Extension
     public function getFunctions()
     {
         return array(
-            'kint' => new Twig_Function_Method($this,'twig_kint', array('is_safe' => array('html'), 'needs_context' => true, 'needs_environment' => true)),
+            'kint' => new Twig_Function_Method($this,'twig_kint', array('is_safe' => array('html'), 'needs_context' => true)),
         );
     }
 
@@ -52,9 +51,9 @@ class KintExtension extends Twig_Extension
         return 'kint';
     }
 
-    public function twig_kint(Twig_Environment $env, $context)
+    public function twig_kint($context)
     {
-        if (!$env->isDebug() || !$this->enabled) {
+        if (!$this->enabled) {
             return;
         }
 


### PR DESCRIPTION
This should be configured using the `enabled` config param so that this can be enabled for an environment even if it is not a debug environment